### PR TITLE
Patch 1

### DIFF
--- a/bisonc++/skeletons/debugfunctions3.in
+++ b/bisonc++/skeletons/debugfunctions3.in
@@ -3,7 +3,7 @@ void \@Base::errorVerbose__()
     std::cout << "Parser State stack containing " << (d_stackIdx__ + 1) <<
                                                                 "elements:\n"
                  "Each line shows a stack index followed "
-                                    by the value of that stack element\n";
+                                    "by the value of that stack element\n";
     for (size_t idx = d_stackIdx__ + 1; idx--; )
        std::cout << std::setw(2) << idx << ": "
                     std::setw(3) << d_stateStack__[idx] << '\n';

--- a/bisonc++/skeletons/debugfunctions3.in
+++ b/bisonc++/skeletons/debugfunctions3.in
@@ -6,6 +6,6 @@ void \@Base::errorVerbose__()
                                     "by the value of that stack element\n";
     for (size_t idx = d_stackIdx__ + 1; idx--; )
        std::cout << std::setw(2) << idx << ": "
-                    std::setw(3) << d_stateStack__[idx] << '\n';
+                 << std::setw(3) << d_stateStack__[idx] << '\n';
 }
 

--- a/bisonc++/skeletons/debugfunctions3.in
+++ b/bisonc++/skeletons/debugfunctions3.in
@@ -1,7 +1,7 @@
 void \@Base::errorVerbose__()
 {
     std::cout << "Parser State stack containing " << (d_stackIdx__ + 1) <<
-                                                                "elements:\n"
+                                                                " elements:\n"
                  "Each line shows a stack index followed "
                                     "by the value of that stack element\n";
     for (size_t idx = d_stackIdx__ + 1; idx--; )


### PR DESCRIPTION
When generating a parser with --error-verbose, the result does not compile. This patch fixes two compile errors and some formatting.
