### PR TITLE
Fixed implementation of emplace for %polymorphic type

### DIFF
--- a/bisonc++/skeletons/bisonc++polymorphic
+++ b/bisonc++/skeletons/bisonc++polymorphic
@@ -71,11 +71,10 @@ $insert polymorphicSpecializations
         DataType d_data;
     
         public:
-                // The default constructor and constructors for 
-                // defined data types are available
-            Semantic();
-            Semantic(DataType const &data);
-            Semantic(DataType &&tmp);
+                // The constructors forward arguments 
+                // to defined data types
+            template <typename ...Args>
+            Semantic(Args &&...args);
 
             DataType &data();
             DataType const &data() const;

--- a/bisonc++/skeletons/bisonc++polymorphic.inline
+++ b/bisonc++/skeletons/bisonc++polymorphic.inline
@@ -12,26 +12,12 @@ inline Tag__ Base::tag() const
 }
 
 template <Tag__ tg_>
-inline Semantic<tg_>::Semantic()
-:
-    Base(tg_),
-    d_data{}
-{}
-
-template <Tag__ tg_>
-inline Semantic<tg_>::Semantic(typename TypeOf<tg_>::type const &data)
+template <typename ...Args>
+inline Semantic<tg_>::Semantic(Args &&...args)
 :
     Base(tg_),
     Base2(0),
-    d_data(data)
-{}
-
-template <Tag__ tg_>
-inline Semantic<tg_>::Semantic(DataType &&tmp)
-:
-    Base(tg_),
-    Base2(0),
-    d_data(std::move(tmp))
+    d_data(std::forward<Args>(args) ...)
 {}
 
 template <Tag__ tg_>


### PR DESCRIPTION
The previous implementation only allowed to use a default, copy or move constructor with "emplace". This patch allows to use any constructor of the underlying type.
