### PR TITLE
Fixed default actions' #line directives being off by one.

### DIFF
--- a/bisonc++/parser/installdefaultaction.cc
+++ b/bisonc++/parser/installdefaultaction.cc
@@ -4,7 +4,7 @@ void Parser::installDefaultAction(Production const &prod,
                                   string const &rhs)
 {
     Block block;
-    block.open(prod.lineNr(), prod.fileName());
+    block.open(prod.lineNr() - 1, prod.fileName());  // account for the newline
 
     block += "\n"
         "    " + s_semanticValue + " = " + rhs + ";\n"


### PR DESCRIPTION
Default actions contain an extra newline, which throws off the C++ compiler when reporting errors. (Default actions normally should not cause errors, but they still might, with some type mismatches.)
This commit fixes it.
