### PR TITLE
Support non-copyable types for %stype and %polymorphic through a lot of hoops.

### DIFF
--- a/bisonc++/parser/installdefaultaction.cc
+++ b/bisonc++/parser/installdefaultaction.cc
@@ -7,7 +7,7 @@ void Parser::installDefaultAction(Production const &prod,
     block.open(prod.lineNr(), prod.fileName());
 
     block += "\n"
-        "    " + s_semanticValue + " = " + rhs + ";\n"
+        "    " + s_semanticValue + " = std::move(" + rhs + ");\n"
         "}";
 
     d_rules.setAction(block);

--- a/bisonc++/skeletons/bisonc++.cc
+++ b/bisonc++/skeletons/bisonc++.cc
@@ -162,7 +162,7 @@ $insert 8 LTYPEresize
     }
     ++d_stackIdx__;
     d_stateStack__[d_stackIdx__] = d_state__ = state;
-    *(d_vsp__ = &d_valueStack__[d_stackIdx__]) = d_val__;
+    *(d_vsp__ = &d_valueStack__[d_stackIdx__]) = std::move(d_val__);
 $insert 4 LTYPEpush
 $insert 4 debug  "push(state " << state << stype__(", semantic TOS = ", d_val__, ")") << ')'
 }
@@ -171,7 +171,7 @@ void \@Base::popToken__()
 {
     d_token__ = d_nextToken__;
 
-    d_val__ = d_nextVal__;
+    d_val__ = std::move(d_nextVal__);
     d_nextVal__ = STYPE__();
 
     d_nextToken__ = _UNDETERMINED_;
@@ -180,7 +180,7 @@ void \@Base::popToken__()
 void \@Base::pushToken__(int token)
 {
     d_nextToken__ = d_token__;
-    d_nextVal__ = d_val__;
+    d_nextVal__ = std::move(d_val__);
     d_token__ = token;
 }
      

--- a/bisonc++/skeletons/bisonc++base.h
+++ b/bisonc++/skeletons/bisonc++base.h
@@ -4,6 +4,7 @@
 #include <exception>
 #include <vector>
 #include <iostream>
+#include <utility>
 
 $insert preincludes
 $insert debugincludes

--- a/bisonc++/skeletons/bisonc++polymorphic
+++ b/bisonc++/skeletons/bisonc++polymorphic
@@ -42,16 +42,39 @@ class Base
         static Base *defaultClone(Base const *obj);
 };
 
+namespace // anonymous
+{
+    template <typename Tp_>
+    using ConstRefType = typename std::conditional< std::is_copy_constructible<Tp_>::value,
+          Tp_ const &,
+          Tp_ >::type;
+    template <typename Tp_>
+    using RefType = typename std::conditional< std::is_copy_constructible<Tp_>::value,
+          Tp_ &,
+          Tp_ && >::type;
+
+    template<class T> RefType<T> maybe_move(T &obj)
+    {
+        return static_cast<RefType<T>>(obj);  // std::move is nothing more than a static cast, too!
+    }
+}
+
+template<Tag__, bool> struct try_clone
+{
+    static Base *clone(Base const *obj);
+};
+
     // The class Semantic is derived from Base. It stores a particular
     // semantic value type. 
 template <Tag__ tg_>
 class Semantic: public Base
 {
     typename TypeOf<tg_>::type d_data;
+    using Copyable = std::is_copy_constructible<typename TypeOf<tg_>::type>;
     
     public:
         Semantic();
-        Semantic(Semantic<tg_> const &other);
+        Semantic(Semantic<tg_> &&other);
 
             // The constructor member template forwards its arguments to
             // d_data, allowing it to be initialized using whatever
@@ -86,7 +109,7 @@ class SType
             // A template member operator= is used because it allows
             // the compiler to deduce the appropriate typename
         template <typename Type>
-        SType &operator=(Type const &value);
+        SType &operator=(Type &&value);
 
         template <Tag__ tag, typename ...Args>
         void assign(Args &&...args);
@@ -94,11 +117,12 @@ class SType
             // By default the get()-members check whether the specified <tag>
             // matches the tag returned by SType::tag (d_data's tag). If they
             // don't match a run-time fatal error results.
+            // Sadly, std::forward cannot do work for us here.
         template <Tag__ tag>
         typename TypeOf<tag>::type &get();
 
         template <Tag__ tag>
-        typename TypeOf<tag>::type const &get() const;
+        ConstRefType<typename TypeOf<tag>::type> get() const;
 
         Tag__ tag() const;
 
@@ -148,9 +172,9 @@ Semantic<tg_>::Semantic()
 }
 
 template <Tag__ tg_>
-Semantic<tg_>::Semantic(Semantic<tg_> const &other)
+Semantic<tg_>::Semantic(Semantic<tg_> &&other)
 :
-    d_data(other.d_data)
+    d_data(std::forward<typename TypeOf<tg_>::type>(other).d_data)
 {
         // Setting Base's data members:
     d_baseTag = other.d_baseTag;
@@ -196,10 +220,10 @@ $insert warnTagMismatches
 }
 
 template <Tag__ tg>
-typename TypeOf<tg>::type const &SType::get() const
+ConstRefType<typename TypeOf<tg>::type> SType::get() const
 {
 $insert warnTagMismatches
-    return *static_cast<typename TypeOf<tg>::type *>(d_base->data());
+    return maybe_move(*static_cast<typename TypeOf<tg>::type *>(d_base->data()));
 }
 
 inline SType::SType()
@@ -233,16 +257,16 @@ inline SType &SType::operator=(SType &&tmp)
     // A template assignment function is used because it allows
     // the compiler to deduce the appropriate typename
 template <typename Type>
-inline SType &SType::operator=(Type const &value)
+inline SType &SType::operator=(Type &&value)
 {
-    assign< TagOf<Type>::tag >(value);
+    assign< TagOf<typename std::remove_reference<Type>::type>::tag >(maybe_move(value));
     return *this;
 }
 
 template <Tag__ tg_>
 inline Base *Semantic<tg_>::clone(Base const *obj) // static
 {
-    return new Semantic<tg_>{*static_cast<Semantic<tg_> const *>(obj)};
+    return try_clone<tg_, Semantic<tg_>::Copyable::value>::clone(obj);
 }
 
 template <Tag__ tg_>
@@ -250,5 +274,28 @@ inline void *Semantic<tg_>::data(Base const *obj) // static
 {
     return &static_cast<Semantic<tg_> *>(const_cast<Base *>(obj))->d_data;
 }
+
+template <Tag__ tg_>
+struct try_clone<tg_, true>
+{
+    inline static Base *clone(Base const *obj)
+    {
+        return new Semantic<tg_>{*static_cast<Semantic<tg_> const*>(obj)};
+    }
+};
+
+template <Tag__ tg_>
+struct try_clone<tg_, false>
+{
+    // TODO Add an option?
+    inline static Base *clone(Base const *obj)
+    {
+        std::cerr << "[Fatal] calling `.clone<Tag__::" << 
+            idOfTag__[static_cast<int>(tg_)] << 
+            ">()', but corresponding type is not copy-constructible. " <<
+            " Try option --rule-numbers\n";
+        throw 1;        // ABORTs
+    }
+};
 
 }  // namespace Meta__


### PR DESCRIPTION
(Hoops mainly involving type_traits).
As it stands, using unique_ptr<>s as your STYPE or as a part of your variant is kind of useful for error recovery (all garbage gets correctly thrown out). Unfortunately,
1. the templates weren't written with move_semantics in mind, and
2. it would be incorrect to just enforce move semantics everywhere, as one user-provided action can reference the same value on the stack multiple times. (However, move semantics are okay for default action, since the value would've got lost anyway.)

Thus, this is a humble attempt to fall back to move semantics for types that do not support copy constructors. It has a lot of conditional types. C'est la vie.
